### PR TITLE
Removed the now unnecessary CPU core config

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -28,9 +28,6 @@ const (
 )
 
 func main() {
-	// This should go away with the next Go version
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	// Read the port from the parameters
 	port := ":80"
 	if len(os.Args) < 2 {


### PR DESCRIPTION
Go now automatically uses all available CPU cores. No need to configure it manuelly at the start any more.
It would be nice if you could add the `hacktoberfest-accepted` tag so it counts towards my progress.